### PR TITLE
feat: Adição de listagem de chamados

### DIFF
--- a/prisma/migrations/20250322002433_add_tipo_documento_and_sentimento_cliente/migration.sql
+++ b/prisma/migrations/20250322002433_add_tipo_documento_and_sentimento_cliente/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Chamado" ADD COLUMN     "sentimento_cliente" TEXT,
+ADD COLUMN     "tipo_documento" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,4 +23,6 @@ model Chamado {
   tipo_importacao    String
   status            String
   data_abertura      DateTime
+  tipo_documento     String? 
+  sentimento_cliente String?
 }

--- a/src/chamado/chamado.controller.ts
+++ b/src/chamado/chamado.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, ParseIntPipe } from '@nestjs/common';
 import { ChamadoService } from './chamado.service';
+import { Chamado } from '@prisma/client';
 
 @Controller('chamados')
 export class ChamadoController {
@@ -13,5 +14,30 @@ export class ChamadoController {
   @Get()
   listarChamados() {
     return this.chamadoService.listarChamados();
+  }
+
+  @Get('paginacao')
+  async listarChamadosPaginados(
+    @Query('page', ParseIntPipe) page: number = 1,
+    @Query('limit', ParseIntPipe) limit: number = 100
+  ): Promise<Chamado[]> {
+    return this.chamadoService.listarChamadosPaginados(page, limit);
+  }
+
+  @Get('status')
+  async listarPorStatus(@Query('status') status: string): Promise<Chamado[]> {
+    return this.chamadoService.listarPorStatus(status);
+  }
+
+  @Get('sentimento')
+  async listarPorSentimento(@Query('sentimento') sentimento: string): Promise<Chamado[]> {
+    return this.chamadoService.listarPorSentimento(sentimento);
+  }
+
+  @Get('tipo-importacao')
+  async listarPorTipoImportacao(
+    @Query('tipo_importacao') tipo_importacao: string
+  ): Promise<Chamado[]> {
+    return this.chamadoService.listarPorTipoImportacao(tipo_importacao);
   }
 }

--- a/src/chamado/chamado.service.ts
+++ b/src/chamado/chamado.service.ts
@@ -4,13 +4,49 @@ import { Chamado } from '@prisma/client';
 
 @Injectable()
 export class ChamadoService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
   async criarChamado(data: Chamado): Promise<Chamado> {
     return this.prisma.chamado.create({ data });
   }
 
   async listarChamados(): Promise<Chamado[]> {
-    return this.prisma.chamado.findMany();
+    return this.prisma.chamado.findMany({
+      orderBy: {
+        ultima_atualizacao: 'desc'
+      }
+    });
+  }
+
+  async listarChamadosPaginados(page: number = 1, limit: number = 100): Promise<Chamado[]> {
+    const offset = (page - 1) * limit;
+    return this.prisma.chamado.findMany({
+      skip: offset,
+      take: limit,
+      orderBy: {
+        ultima_atualizacao: 'desc'
+      }
+    });
+  }
+
+  async listarPorStatus(status: string): Promise<Chamado[]> {
+    return this.prisma.chamado.findMany({
+      where: { status },
+      orderBy: { ultima_atualizacao: 'desc' },
+    });
+  }
+
+  async listarPorSentimento(sentimento: string): Promise<Chamado[]> {
+    return this.prisma.chamado.findMany({
+      where: { sentimento_cliente: sentimento },
+      orderBy: { ultima_atualizacao: 'desc' },
+    });
+  }
+
+  async listarPorTipoImportacao(tipo_importacao: string): Promise<Chamado[]> {
+    return this.prisma.chamado.findMany({
+      where: { tipo_importacao },
+      orderBy: { ultima_atualizacao: 'desc' },
+    });
   }
 }


### PR DESCRIPTION
Adição dos campos "sentimento_cliente" e "tipo_documento" nas migrações.

para atualizar o banco executar o comando "npx prisma generate".

rotas para as listagens:
http://localhost:3000/chamados
http://localhost:3000/chamados/paginacao?page=1&limit=10
http://localhost:3000/chamados/status?status=Resolvido
http://localhost:3000/chamados/sentimento?sentimento=Neutro
http://localhost:3000/chamados/tipo-importacao?tipo_importacao=Jira