### PR TITLE
feat: Adição de coluna + função para salvar keywords de um chamado

### DIFF
--- a/prisma/migrations/20250517002255_add_keywords_to_chamado/migration.sql
+++ b/prisma/migrations/20250517002255_add_keywords_to_chamado/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Chamado" ADD COLUMN     "keywords" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Chamado {
   nome_arquivo       NomeArquivo? @relation(fields: [nomeArquivoId], references: [id])
   nomeArquivoId      Int? 
   sumarizacao        String?
+  keywords           Json?
 }
 
 model NomeArquivo {

--- a/src/chamado/chamado.controller.ts
+++ b/src/chamado/chamado.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Query, ParseIntPipe, Param, Logger, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Post, Body, Query, ParseIntPipe, Param, Logger, NotFoundException, Patch } from '@nestjs/common';
 import { ChamadoService } from './chamado.service';
 import { Chamado } from '@prisma/client';
 
@@ -85,4 +85,12 @@ export class ChamadoController {
     return await this.chamadoService.listarChamadosPorNomeArquivoId(nomeArquivoId);
   }
 
+  @Patch('atualizar-keywords/:id')
+  async atualizarKeywords(
+    @Param('id') chamadoId: string,
+    @Body('keywords') keywords: any,
+  ) {
+    this.logger.log(`Recebendo atualização de keywords para o chamado ${chamadoId}`);
+    return await this.chamadoService.atualizarKeywords(chamadoId, keywords);
+  }
 }


### PR DESCRIPTION
Adicionei uma nova coluna chamada keywords:

Necessário rodar os comandos:
npx prisma migrate dev
npx prisma generate

e também adicionei a função para atualizar os chamados com os keywords extraidos do repositório "busca-semantica"